### PR TITLE
Babel was throwing a "Don't hotlink internal Babel files.” error.  Fi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rx": "2.5.3"
   },
   "devDependencies": {
-    "babel": "5.5.x",
+    "babel": "5.6.x",
     "babelify": "6.1.x",
     "eslint": "^0.23.0",
     "eslint-config-cycle": "1.0.x",


### PR DESCRIPTION
…xed simply by updating to latest babel.