### PR TITLE
Updated to rx 4.0.6 to fix fromEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "lib/cycle.js",
   "dependencies": {
-    "rx": "4.0.1"
+    "rx": "4.0.6"
   },
   "devDependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
```Rx.Observable.fromEvent``` is broken in rx@4.0.1 and fixed in 4.0.6. This affects drivers that are importing ```Rx``` via ```@cycle/core```.