### PR TITLE
feat(): Allow for conversions between stream libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,17 @@
   "devDependencies": {
     "babel": "5.8.29",
     "babelify": "6.4.0",
+    "baconjs": "^0.7.83",
     "browserify": "12.0.1",
     "browserify-shim": "3.8.11",
     "eslint": "1.0.0",
     "eslint-config-cycle": "3.0.0",
     "eslint-plugin-cycle": "1.0.1",
     "eslint-plugin-no-class": "0.1.0",
+    "kefir": "^3.2.0",
     "markdox": "0.1.10",
     "mocha": "2.3.3",
+    "most": "^0.17.0",
     "rx": "4.0.6",
     "sinon": "1.17.2",
     "testem": "0.9.11",
@@ -63,5 +66,8 @@
     "release-patch": "git checkout master && npm run dist; git commit -a -m 'Build dist/'; npm version patch && git push origin master --tags && npm publish --access=public",
     "release-minor": "git checkout master && npm run dist; git commit -a -m 'Build dist/'; npm version minor && git push origin master --tags && npm publish --access=public",
     "release-major": "git checkout master && npm run dist; git commit -a -m 'Build dist/'; npm version major && git push origin master --tags && npm publish --access=public"
+  },
+  "dependencies": {
+    "stream-conversions": "^0.2.0"
   }
 }


### PR DESCRIPTION
Allows interchangeability between all libraries supported
by the stream-conversions library. Injects a second parameter into
driver functions for converting streams from one library to another.