### PR TITLE
add empty dependencies object

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "virtual-dom"
   ],
   "main": "lib/cycle.js",
+  "dependencies": {},
   "peerDependencies": {
     "rx": "*"
   },


### PR DESCRIPTION
due to bug in npm:

- https://github.com/npm/npm/issues/6581#issuecomment-174718361
- https://github.com/facebook/react/issues/5918#issuecomment-174710988

This bug breaks bundling modules via [browserify-cdn](https://wzrd.in/). Please merge this and patch version ASAP. Thanks!