### PR TITLE
Tiny refactoring and optimization

### DIFF
--- a/src/cycle.js
+++ b/src/cycle.js
@@ -1,17 +1,22 @@
 let Rx = require(`rx`)
 
 function makeSinkProxies(drivers) {
-  return Object.keys(drivers).reduce((sinkProxies, name) => {
-    sinkProxies[name] = new Rx.ReplaySubject(1)
-    return sinkProxies
-  }, {})
+  let sinkProxies = {}
+  let keys = Object.keys(drivers)
+  for (let i = 0; i < keys.length; i++) {
+    sinkProxies[keys[i]] = new Rx.ReplaySubject(1)
+  }
+  return sinkProxies
 }
 
 function callDrivers(drivers, sinkProxies) {
-  return Object.keys(drivers).reduce((sources, name) => {
+  let sources = {}
+  let keys = Object.keys(drivers)
+  for (let i = 0; i < keys.length; i++) {
+    let name = keys[i]
     sources[name] = drivers[name](sinkProxies[name], name)
-    return sources
-  }, {})
+  }
+  return sources
 }
 
 function attachDisposeToSinks(sinks, replicationSubscription) {
@@ -22,7 +27,9 @@ function attachDisposeToSinks(sinks, replicationSubscription) {
 
 function makeDisposeSources(sources) {
   return function dispose() {
-    for (let source of Object.values(sources)) {
+    let keys = Object.keys(sources)
+    for (let i = 0; i < keys.length; i++) {
+      let source = sources[keys[i]]
       if (typeof source.dispose === `function`) {
         source.dispose()
       }
@@ -44,7 +51,9 @@ function replicateMany(observables, subjects) {
   return Rx.Observable.create(observer => {
     let subscription = new Rx.CompositeDisposable()
     setTimeout(() => {
-      for (let name of Object.keys(observables)) {
+      let keys = Object.keys(observables)
+      for (let i = 0; i < keys.length; i++) {
+        let name = keys[i]
         if (subjects.hasOwnProperty(name) && !subjects[name].isDisposed) {
           subscription.add(
             observables[name]
@@ -58,8 +67,9 @@ function replicateMany(observables, subjects) {
 
     return function dispose() {
       subscription.dispose()
-      for (let subject of Object.values(subjects)) {
-        subject.dispose()
+      let keys = Object.keys(subjects)
+      for (let i = 0; i < keys.length; i++) {
+        subjects[keys[i]].dispose()
       }
     }
   })

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -30,11 +30,9 @@ function attachDisposeToSinks(sinks, replicationSubscription) {
 
 function makeDisposeSources(sources) {
   return function dispose() {
-    for (let name in sources) {
-      if (sources.hasOwnProperty(name) &&
-        typeof sources[name].dispose === `function`)
-      {
-        sources[name].dispose()
+    for (let source of Object.values(sources)) {
+      if (typeof source.dispose === `function`) {
+        source.dispose()
       }
     }
   }
@@ -73,10 +71,8 @@ function replicateMany(observables, subjects) {
 
     return function dispose() {
       subscription.dispose()
-      for (let x in subjects) {
-        if (subjects.hasOwnProperty(x)) {
-          subjects[x].dispose()
-        }
+      for (let subject of Object.values(subjects)) {
+        subject.dispose()
       }
     }
   })

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -85,15 +85,6 @@ function replicateMany(observables, subjects) {
   })
 }
 
-function isObjectEmpty(obj) {
-  for (let key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      return false
-    }
-  }
-  return true
-}
-
 function run(main, drivers) {
   if (typeof main !== `function`) {
     throw new Error(`First argument given to Cycle.run() must be the 'main' ` +
@@ -103,7 +94,7 @@ function run(main, drivers) {
     throw new Error(`Second argument given to Cycle.run() must be an object ` +
       `with driver functions as properties.`)
   }
-  if (isObjectEmpty(drivers)) {
+  if (Object.keys(drivers).length === 0) {
     throw new Error(`Second argument given to Cycle.run() must be an object ` +
       `with at least one driver function declared as a property.`)
   }

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -69,7 +69,7 @@ function replicateMany(observables, subjects) {
         }
       }
       observer.onNext(subscription)
-    }, 1)
+    })
 
     return function dispose() {
       subscription.dispose()

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -21,11 +21,9 @@ function callDrivers(drivers, sinkProxies) {
 }
 
 function attachDisposeToSinks(sinks, replicationSubscription) {
-  Object.defineProperty(sinks, `dispose`, {
-    enumerable: false,
-    value: () => { replicationSubscription.dispose() },
+  return Object.defineProperty(sinks, `dispose`, {
+    value() { replicationSubscription.dispose() },
   })
-  return sinks
 }
 
 function makeDisposeSources(sources) {
@@ -39,11 +37,9 @@ function makeDisposeSources(sources) {
 }
 
 function attachDisposeToSources(sources) {
-  Object.defineProperty(sources, `dispose`, {
-    enumerable: false,
+  return Object.defineProperty(sources, `dispose`, {
     value: makeDisposeSources(sources),
   })
-  return sources
 }
 
 let logToConsoleError = typeof console !== `undefined` && console.error

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -1,23 +1,17 @@
 let Rx = require(`rx`)
 
 function makeSinkProxies(drivers) {
-  let sinkProxies = {}
-  for (let name in drivers) {
-    if (drivers.hasOwnProperty(name)) {
-      sinkProxies[name] = new Rx.ReplaySubject(1)
-    }
-  }
-  return sinkProxies
+  return Object.keys(drivers).reduce((sinkProxies, name) => {
+    sinkProxies[name] = new Rx.ReplaySubject(1)
+    return sinkProxies
+  }, {})
 }
 
 function callDrivers(drivers, sinkProxies) {
-  let sources = {}
-  for (let name in drivers) {
-    if (drivers.hasOwnProperty(name)) {
-      sources[name] = drivers[name](sinkProxies[name], name)
-    }
-  }
-  return sources
+  return Object.keys(drivers).reduce((sources, name) => {
+    sources[name] = drivers[name](sinkProxies[name], name)
+    return sources
+  }, {})
 }
 
 function attachDisposeToSinks(sinks, replicationSubscription) {
@@ -50,11 +44,8 @@ function replicateMany(observables, subjects) {
   return Rx.Observable.create(observer => {
     let subscription = new Rx.CompositeDisposable()
     setTimeout(() => {
-      for (let name in observables) {
-        if (observables.hasOwnProperty(name) &&
-          subjects.hasOwnProperty(name) &&
-          !subjects[name].isDisposed)
-        {
+      for (let name of Object.keys(observables)) {
+        if (subjects.hasOwnProperty(name) && !subjects[name].isDisposed) {
           subscription.add(
             observables[name]
               .doOnError(logToConsoleError)

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -48,12 +48,9 @@ function attachDisposeToSources(sources) {
   return sources
 }
 
-function logToConsoleError(err) {
-  let target = err.stack || err
-  if (console && console.error) {
-    console.error(target)
-  }
-}
+let logToConsoleError = typeof console !== `undefined` && console.error
+  ? error => { console.error(error.stack || error) }
+  : Function.prototype
 
 function replicateMany(observables, subjects) {
   return Rx.Observable.create(observer => {


### PR DESCRIPTION
1. Replace `for in` with `Object.{keys, values}`. Why?
  * It is harmony-way to handle objects
  * Less code: removes repetition of `hasOwnProperty` calls
  * More functional: `reduce` operates only on parameters
  * Semantically correct: `for in` is for enumerating prototype chain, `Object.keys` is for own props
  * Cross-browser: in ES5 `for in` was slightly changed and only Firefox implemented new behaviour (see [compat-table](https://github.com/kangax/compat-table/blob/gh-pages/data-es5.js#L1325) for details)
  * Faster: `let` creates unnecessary binding on every iteration. `for in` may prevent the whole function from being optimized by V8 (see [optimization-killers](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#52-the-object-being-iterated-is-not-a-simple-enumerable) for details)
  * More robust: `if (drivers.hasOwnProperty(name))` will throw if user passes `Object.create(null)` thing.
2. Define `logToConsoleError` conditionally and replace `console &&` with `typeof console !== 'undefined'` because babel enforces strict mode and former will throw. `Function.prototype` is built-in noop.
3. `return Object.defineProperty` because it always returns first argument. Remove `enumerable: false` because it is default value for undefined props.
4. Drop second argument from `setTimeout` call. Why? Removes ambiguity. `1` is default for Node, but `setTimeout` in browsers treat `0..4` as `4` (in most cases).
5. Replace `isObjectEmpty` with `Object.keys().length`. Latter is more specific on what *empty* means (no enumerable props).